### PR TITLE
Feat scale images with max width

### DIFF
--- a/src/HTMLImage.js
+++ b/src/HTMLImage.js
@@ -59,6 +59,14 @@ export default class HTMLImage extends PureComponent {
                 if (!width && styles['width']) {
                     styleWidth = styles['width'];
                 }
+                if (!width && styles['maxWidth'] <= 100) {
+                    styleWidth = styles['maxWidth'];
+                    if (styles['maxHeight']) {
+                        styleHeight = styles['maxHeight']
+                    } else {
+                        styleHeight = styles['maxWidth'];
+                    }
+                }
                 if (!height && styles['height']) {
                     styleHeight = styles['height'];
                 }
@@ -66,6 +74,14 @@ export default class HTMLImage extends PureComponent {
         } else {
             if (!width && style['width']) {
                 styleWidth = style['width'];
+            }
+            if (!width && style['maxWidth'] <= 100) {
+                styleWidth = style['maxWidth'];
+                if (style['maxHeight']) {
+                    styleHeight = style['maxHeight']
+                } else {
+                    styleHeight = style['maxWidth'];
+                }
             }
             if (!height && style['height']) {
                 styleHeight = style['height'];

--- a/types/react-native-render-html/index.d.ts
+++ b/types/react-native-render-html/index.d.ts
@@ -236,3 +236,7 @@ declare module "react-native-render-html/src/HTMLUtils" {
    */
   const IGNORED_TAGS: string[];
 }
+
+declare module "react-native-render-html/src/HTMLRenderers" {
+  function img (htmlAttribs: any, children: any, convertedCSSStyles: any, key: any): false | JSX.Element;
+}


### PR DESCRIPTION
- Scale small images (less than 100px) by using `max-width`.
- Add typescript declaration for `img` function in `HTMLRenderers` to be used as a custom `renderers` for inline image.